### PR TITLE
Feature/question1

### DIFF
--- a/intern_2week_study.xcodeproj/xcshareddata/xcschemes/intern_2week_study.xcscheme
+++ b/intern_2week_study.xcodeproj/xcshareddata/xcschemes/intern_2week_study.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "083FD6FB24C33D2900383122"
+               BuildableName = "intern_2week_study.app"
+               BlueprintName = "intern_2week_study"
+               ReferencedContainer = "container:intern_2week_study.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "083FD6FB24C33D2900383122"
+            BuildableName = "intern_2week_study.app"
+            BlueprintName = "intern_2week_study"
+            ReferencedContainer = "container:intern_2week_study.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "083FD6FB24C33D2900383122"
+            BuildableName = "intern_2week_study.app"
+            BlueprintName = "intern_2week_study"
+            ReferencedContainer = "container:intern_2week_study.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/intern_2week_study/Base.lproj/LaunchScreen.storyboard
+++ b/intern_2week_study/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,9 +13,9 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -67,8 +67,8 @@
                         <viewLayoutGuide key="safeArea" id="tUl-ih-lXm"/>
                     </view>
                     <connections>
-                        <outlet property="buttonToAddText" destination="mcD-4C-Lu1" id="1Oy-fX-5Mt"/>
-                        <outlet property="buttonToClearText" destination="5pp-4y-HTr" id="NZO-cJ-EBg"/>
+                        <outlet property="addButton" destination="mcD-4C-Lu1" id="VXc-Iu-ru6"/>
+                        <outlet property="clearButton" destination="5pp-4y-HTr" id="V6P-Cp-5YG"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
                         <outlet property="warningLabel" destination="1Ja-zD-HJp" id="VcC-PK-bZW"/>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -47,6 +47,13 @@
                                 </constraints>
                                 <state key="normal" title="Add"/>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="文字を入力してください" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Ja-zD-HJp" userLabel="Warning label">
+                                <rect key="frame" x="86" y="276" width="135" height="15"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
@@ -64,6 +71,7 @@
                         <outlet property="clearTextButton" destination="5pp-4y-HTr" id="pjt-CS-Lp9"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
+                        <outlet property="warningLabel" destination="1Ja-zD-HJp" id="VcC-PK-bZW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nhm-ii-iwx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -67,8 +67,8 @@
                         <viewLayoutGuide key="safeArea" id="tUl-ih-lXm"/>
                     </view>
                     <connections>
-                        <outlet property="addTextButton" destination="mcD-4C-Lu1" id="KFf-4J-dPr"/>
-                        <outlet property="clearTextButton" destination="5pp-4y-HTr" id="pjt-CS-Lp9"/>
+                        <outlet property="buttonToAddText" destination="mcD-4C-Lu1" id="1Oy-fX-5Mt"/>
+                        <outlet property="buttonToClearText" destination="5pp-4y-HTr" id="NZO-cJ-EBg"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
                         <outlet property="warningLabel" destination="1Ja-zD-HJp" id="VcC-PK-bZW"/>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -35,34 +35,40 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5pp-4y-HTr">
+                                <rect key="frame" x="228" y="299" width="100" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Clear"/>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mcD-4C-Lu1">
-                                <rect key="frame" x="87" y="314" width="240" height="30"/>
+                                <rect key="frame" x="86" y="299" width="100" height="30"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="240" id="0PX-k5-h7v"/>
+                                    <constraint firstAttribute="width" constant="100" id="0PX-k5-h7v"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
+                                <state key="normal" title="Add"/>
                             </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="5CN-E1-JLh"/>
-                            <constraint firstItem="h1I-2B-V7f" firstAttribute="top" secondItem="mcD-4C-Lu1" secondAttribute="bottom" constant="40" id="7sh-Zw-yFY"/>
-                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="40" id="9S7-3c-cYn"/>
-                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="a4S-bN-by9"/>
+                            <constraint firstItem="h1I-2B-V7f" firstAttribute="top" secondItem="mcD-4C-Lu1" secondAttribute="bottom" constant="55" id="7sh-Zw-yFY"/>
+                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="25" id="9S7-3c-cYn"/>
+                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" constant="-71" id="a4S-bN-by9"/>
                             <constraint firstItem="SAC-3D-GIS" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="l5m-Al-GqV"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerY" secondItem="AJf-tg-maZ" secondAttribute="centerY" id="qxP-vA-nDO"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tUl-ih-lXm"/>
                     </view>
                     <connections>
-                        <outlet property="addTextButton" destination="mcD-4C-Lu1" id="mCX-sP-Nbt"/>
+                        <outlet property="addTextButton" destination="mcD-4C-Lu1" id="KFf-4J-dPr"/>
+                        <outlet property="clearTextButton" destination="5pp-4y-HTr" id="pjt-CS-Lp9"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nhm-ii-iwx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-314" y="66"/>
+            <point key="canvasLocation" x="-314.49275362318843" y="65.625"/>
         </scene>
     </scenes>
 </document>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text View" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
                                 <rect key="frame" x="87" y="384" width="240" height="128"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -4,8 +4,8 @@ final class Question1ViewController: UIViewController {
     
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var warningLabel: UILabel!
-    @IBOutlet weak var addTextButton: UIButton!
-    @IBOutlet weak var clearTextButton: UIButton!
+    @IBOutlet weak var buttonToAddText: UIButton!
+    @IBOutlet weak var buttonToClearText: UIButton!
     @IBOutlet weak var textView: UITextView!
     
     func addFuncToButton(_ button: UIButton!, _ selector: Selector) {
@@ -14,8 +14,8 @@ final class Question1ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        addFuncToButton(addTextButton, #selector(addText(_:)))
-        addFuncToButton(clearTextButton, #selector(clearText(_:)))
+        addFuncToButton(buttonToAddText, #selector(addText(_:)))
+        addFuncToButton(buttonToClearText, #selector(clearText(_:)))
         textView.text = ""
         warningLabel.isHidden = true
     }

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -8,16 +8,16 @@ final class Question1ViewController: UIViewController {
     @IBOutlet weak var buttonToClearText: UIButton!
     @IBOutlet weak var textView: UITextView!
     
-    func addFuncToButton(_ button: UIButton!, _ selector: Selector) {
-        button.addTarget(self, action: selector, for: UIControl.Event.touchUpInside)
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         addFuncToButton(buttonToAddText, #selector(addText(_:)))
         addFuncToButton(buttonToClearText, #selector(clearText(_:)))
         textView.text = ""
         warningLabel.isHidden = true
+    }
+    
+    func addFuncToButton(_ button: UIButton!, _ selector: Selector) {
+        button.addTarget(self, action: selector, for: UIControl.Event.touchUpInside)
     }
     
     @objc func addText(_ sender: UIButton) {

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -4,9 +4,21 @@ final class Question1ViewController: UIViewController {
     
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var addTextButton: UIButton!
+    @IBOutlet weak var clearTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        addTextButton.addTarget(self, action: #selector(addText(_:)), for: UIControl.Event.touchUpInside)
+        clearTextButton.addTarget(self, action: #selector(clearText(_:)), for: UIControl.Event.touchUpInside)
+        textView.text = ""
+    }
+    
+    @objc func addText(_ sender: UIButton) {
+        textView.text += "\n" + textField.text!
+    }
+    
+    @objc func clearText(_ sender: UIButton) {
+        textView.text = ""
     }
 }

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -21,7 +21,7 @@ final class Question1ViewController: UIViewController {
     }
     
     @objc func addText(_ sender: UIButton) {
-        if textField.text! == "" {
+        if textField.text == "" {
             warningLabel.isHidden = false
             return
         }

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -8,10 +8,14 @@ final class Question1ViewController: UIViewController {
     @IBOutlet weak var clearTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
     
+    func addFuncToButton(_ button: UIButton!, _ selector: Selector) {
+        button.addTarget(self, action: selector, for: UIControl.Event.touchUpInside)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        addTextButton.addTarget(self, action: #selector(addText(_:)), for: UIControl.Event.touchUpInside)
-        clearTextButton.addTarget(self, action: #selector(clearText(_:)), for: UIControl.Event.touchUpInside)
+        addFuncToButton(addTextButton, #selector(addText(_:)))
+        addFuncToButton(clearTextButton, #selector(clearText(_:)))
         textView.text = ""
         warningLabel.isHidden = true
     }

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 final class Question1ViewController: UIViewController {
     
     @IBOutlet weak var textField: UITextField!
+    @IBOutlet weak var warningLabel: UILabel!
     @IBOutlet weak var addTextButton: UIButton!
     @IBOutlet weak var clearTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
@@ -12,9 +13,15 @@ final class Question1ViewController: UIViewController {
         addTextButton.addTarget(self, action: #selector(addText(_:)), for: UIControl.Event.touchUpInside)
         clearTextButton.addTarget(self, action: #selector(clearText(_:)), for: UIControl.Event.touchUpInside)
         textView.text = ""
+        warningLabel.isHidden = true
     }
     
     @objc func addText(_ sender: UIButton) {
+        if textField.text! == "" {
+            warningLabel.isHidden = false
+            return
+        }
+        warningLabel.isHidden = true
         textView.text += "\n" + textField.text!
     }
     

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -4,8 +4,16 @@ final class Question1ViewController: UIViewController {
     
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var warningLabel: UILabel!
-    @IBOutlet weak var addButton: UIButton!
-    @IBOutlet weak var clearButton: UIButton!
+    @IBOutlet weak var addButton: UIButton! {
+        didSet {
+            addButton.addTarget(self, action: #selector(addText(_:)), for: .touchUpInside)
+        }
+    }
+    @IBOutlet weak var clearButton: UIButton! {
+        didSet {
+            addButton.addTarget(self, action: #selector(addText(_:)), for: .touchUpInside)
+        }
+    }
     @IBOutlet weak var textView: UITextView!
     
     override func viewDidLoad() {

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -28,12 +28,12 @@ final class Question1ViewController: UIViewController {
     }
     
     @objc func addText(_ sender: UIButton) {
-        if textField.text == "" {
+        guard let text = textField.text, !text.isEmpty else {
             warningLabel.isHidden = false
             return
         }
         warningLabel.isHidden = true
-        textView.text += "\n" + textField.text!
+        textView.text += "\n" + text
     }
     
     @objc func clearText(_ sender: UIButton) {

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -4,15 +4,14 @@ final class Question1ViewController: UIViewController {
     
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var warningLabel: UILabel!
-    @IBOutlet weak var buttonToAddText: UIButton!
-    @IBOutlet weak var buttonToClearText: UIButton!
+    @IBOutlet weak var addButton: UIButton!
+    @IBOutlet weak var clearButton: UIButton!
     @IBOutlet weak var textView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        addFuncToButton(buttonToAddText, #selector(addText(_:)))
-        addFuncToButton(buttonToClearText, #selector(clearText(_:)))
-        textView.text = ""
+        addFuncToButton(addButton, #selector(addText(_:)))
+        addFuncToButton(clearButton, #selector(clearText(_:)))
         warningLabel.isHidden = true
     }
     


### PR DESCRIPTION
課題
---
- [課題1 · Issue #1 · Caraquri/intern_2week_study_ios](https://github.com/Caraquri/intern_2week_study_ios/issues/1])

概要
---
- `addButton`を押した際に`textField`に入っている文字を`textView`に追加する処理を実装
  - 起動時に`textView`を空にする
  - `textView`は改行してから追加する
- `clearTextButton`を追加し、`textView`の文字を消す処理を実装
- `addButton`を押した際、`textField`に文字が入っていない場合は`textView`に追加できないようにする処理を追加
  - その際は、`TextField`の下にLabelを追加し「赤文字」で「文字を入力してください」と警告を表示

特に確認して頂きたい項目
---
- ボタン押下時のアクションの書き方が適切か
  - `@IBAction`を使う方法と`UIButton.addTarget`を使う方法の二つを見つけたが、どちらを使用すべきか
  - 今回は、どのボタンのアクションなのか一眼見て分かる後者が適切だと思ったため、`UIButton.addTarget`を使用した

- `addFuncToButton`関数が適切か
  - `addTarget`を使う際、
`addTextButton.addTarget(self, action: #selector(addText(_:)),for: UIControl.Event.touchUpInside)`という風に書いていたが、これだと処理が長い上にパッと見たときに何をしているのかすぐに分かりづらいかなと思ったため、`addFuncToButton`関数を作成して簡潔に処理を書けるようにした
  - 自分は見やすいと思い作成しましたが、これについてどう思うかお聞きしたいです

- 他にもっと良い処理の実装方法はあるか

動作確認用 Screenshots
---
<img src="https://user-images.githubusercontent.com/47961006/89991933-86674300-dcbf-11ea-9216-e9c0dd29788e.gif" width="300" />

参考URL
---
[【Swift】addTargetメソッドの使い方、引数selector、senderのおさらい](https://pg-happy.jp/swift-addtarget.html)
